### PR TITLE
Change calc_percentile argument range from [0,100] to [0,1] (#149)

### DIFF
--- a/python/tensoromics_functions.py
+++ b/python/tensoromics_functions.py
@@ -1884,14 +1884,14 @@ def tox_compute_rdi(distances, gene_to_fam, dscale):
 
 
 #> tox_get_outliers:identify_outliers_c: Identify outliers based on RDI percentile or threshold
-def tox_identify_outliers(rdi, threshold=None, percentile=95.0):
+def tox_identify_outliers(rdi, threshold=None, percentile=0.95):
     """
     Identify outliers based on RDI percentile or threshold
 
     Args:
         rdi: Relative Distance Index values
         threshold: Fixed RDI threshold (if None, uses percentile)
-        percentile: Percentile threshold for outlier detection (default: 95 for top 5%)
+        percentile: Percentile threshold in [0,1] for outlier detection (default: 0.95 for top 5%)
 
     Returns:
         dict: Dictionary containing:
@@ -1949,14 +1949,14 @@ def tox_identify_outliers(rdi, threshold=None, percentile=95.0):
 
 
 #> tox_get_outliers:detect_outliers_c: Complete outlier detection pipeline
-def tox_detect_outliers(distances, gene_to_fam, percentile=95.0):
+def tox_detect_outliers(distances, gene_to_fam, percentile=0.95):
     """
     Complete outlier detection pipeline
 
     Args:
         distances: Gene distances to centroids
         gene_to_fam: Gene-to-family mapping
-        percentile: Percentile threshold for outlier detection (default: 95 for top 5%)
+        percentile: Percentile threshold in [0,1] for outlier detection (default: 0.95 for top 5%)
 
     Returns:
         dict: Dictionary containing outliers and intermediate results

--- a/python/tensoromics_functions.py
+++ b/python/tensoromics_functions.py
@@ -3543,7 +3543,7 @@ def tox_compute_p_values(local_contributions_observed,
 def tox_determine_shared_residual_range_expert(
     residual_pool,
     residual_pool_perm,
-    residual_range_quantile=95.0,
+    residual_range_quantile=0.95,
 ):
     """
     Compute shared residual range R from two residual matrices.
@@ -3551,7 +3551,7 @@ def tox_determine_shared_residual_range_expert(
     Args:
         residual_pool: np.ndarray (pool_size), pool_size is usually `(n_reps_S1 + n_reps_2)*n_neighbors*n_points`
         residual_pool_perm: np.ndarray (pool_size), permutation vector that sorts `residual_pool`
-        residual_range_quantile: float
+        residual_range_quantile: float, quantile in [0,1] (default 0.95)
 
     Returns:
         float: shared_residual_range
@@ -3596,7 +3596,7 @@ def tox_determine_shared_residual_range_expert(
 def tox_determine_shared_residual_range(
     neighborhood_residuals_S1,
     neighborhood_residuals_S2,
-    residual_range_quantile=95.0,
+    residual_range_quantile=0.95,
 ):
     """
     Compute shared residual range R from two residual matrices.
@@ -3605,7 +3605,7 @@ def tox_determine_shared_residual_range(
     Args:
         neighborhood_residuals_S1: np.ndarray (n_reps_S1, n_neighbors, n_points)
         neighborhood_residuals_S2: np.ndarray (n_reps_S2, n_neighbors, n_points)
-        residual_range_quantile: float
+        residual_range_quantile: float, quantile in [0,1] (default 0.95)
 
     Returns:
         float: shared_residual_range

--- a/python/test/mod_test_data_integration_jsd.py
+++ b/python/test/mod_test_data_integration_jsd.py
@@ -42,13 +42,13 @@ def test_tox_determine_shared_residual_range():
     S2[:, 0, 1] = [5,  7,  9]
     S2[:, 1, 1] = [0,  1,  2]
 
-    R = tox_determine_shared_residual_range(S1, S2, 95.0)
+    R = tox_determine_shared_residual_range(S1, S2, 0.95)
     assert abs(R - 10.65) < TOL, f"Test 1 failed: expected 10.65, got {R}"
 
     # ============================================================
-    # Test 2 — Custom quantile (50%)
+    # Test 2 — Custom quantile (median, q=0.5)
     # ============================================================
-    R = tox_determine_shared_residual_range(S1, S2, 50.0)
+    R = tox_determine_shared_residual_range(S1, S2, 0.5)
     assert abs(R - 4.0) < TOL, f"Test 2 failed: expected 4.0, got {R}"
 
     # ============================================================
@@ -57,9 +57,9 @@ def test_tox_determine_shared_residual_range():
     assert_error(lambda: tox_determine_shared_residual_range(S1, S2, -1.0), "Test 3 failed: expected ERR_INVALID_INPUT")
 
     # ============================================================
-    # Test 4 — Quantile > 100 → error
+    # Test 4 — Quantile > 1 → error
     # ============================================================
-    assert_error(lambda: tox_determine_shared_residual_range(S1, S2, 150.0), "Test 4 failed: expected ERR_INVALID_INPUT")
+    assert_error(lambda: tox_determine_shared_residual_range(S1, S2, 1.5), "Test 4 failed: expected ERR_INVALID_INPUT")
 
     # ============================================================
     # Test 5 — NaNs must be ignored
@@ -79,7 +79,7 @@ def test_tox_determine_shared_residual_range():
     S1[0, 0, 0] = np.nan
     S2[2, 1, 1] = np.nan
 
-    R = tox_determine_shared_residual_range(S1, S2, 95.0)
+    R = tox_determine_shared_residual_range(S1, S2, 0.95)
     assert abs(R - 11.0) < TOL, f"Test 5 failed: expected 11.0, got {R}"
 
     # ============================================================
@@ -88,7 +88,7 @@ def test_tox_determine_shared_residual_range():
     S1[:, :, :] = 0
     S2[:, :, :] = 0
 
-    R = tox_determine_shared_residual_range(S1, S2, 95.0)
+    R = tox_determine_shared_residual_range(S1, S2, 0.95)
     assert abs(R - 0.0) < TOL, f"Test 6 failed: expected 0.0, got {R}"
 
     # ============================================================
@@ -97,7 +97,7 @@ def test_tox_determine_shared_residual_range():
     S1 = np.array([[[3.0]]], dtype=np.float64, order="F")
     S2 = np.array([[[-4.0]]], dtype=np.float64, order="F")
 
-    R = tox_determine_shared_residual_range(S1, S2, 95.0)
+    R = tox_determine_shared_residual_range(S1, S2, 0.95)
     assert abs(R - 3.95) < TOL, f"Test 7 failed: expected 3.95, got {R}"
 
 
@@ -130,9 +130,9 @@ def test_tox_determine_shared_residual_range_expert():
     assert abs(R - 10.85) < TOL, f"Test 1 failed: expected 10.85, got {R}"
 
     # ============================================================
-    # Test 2 — Custom quantile (50%)
+    # Test 2 — Custom quantile (median, q=0.5)
     # ============================================================
-    R = tox_determine_shared_residual_range_expert(pool, perm, 50.0)
+    R = tox_determine_shared_residual_range_expert(pool, perm, 0.5)
     assert abs(R - 5.0) < TOL, f"Test 2 failed: expected 5.0, got {R}"
 
     # ============================================================
@@ -141,9 +141,9 @@ def test_tox_determine_shared_residual_range_expert():
     assert_error(lambda: tox_determine_shared_residual_range_expert(pool, perm, -1.0), "Test 3 failed: expected ERR_INVALID_INPUT")
 
     # ============================================================
-    # Test 4 — Quantile > 100 → error
+    # Test 4 — Quantile > 1 → error
     # ============================================================
-    assert_error(lambda: tox_determine_shared_residual_range_expert(pool, perm, 150.0), "Test 4 failed: expected ERR_INVALID_INPUT")
+    assert_error(lambda: tox_determine_shared_residual_range_expert(pool, perm, 1.5), "Test 4 failed: expected ERR_INVALID_INPUT")
 
     # ============================================================
     # Test 5 — NaNs must be ignored
@@ -159,7 +159,7 @@ def test_tox_determine_shared_residual_range_expert():
     S2[3, 2] = np.nan
 
     pool, perm = make_pool(S1, S2)
-    R = tox_determine_shared_residual_range_expert(pool, perm, 95.0)
+    R = tox_determine_shared_residual_range_expert(pool, perm, 0.95)
     assert abs(R - 11.0) < TOL, f"Test 5 failed: expected 11.0, got {R}"
 
     # ============================================================
@@ -169,7 +169,7 @@ def test_tox_determine_shared_residual_range_expert():
     S2 = np.zeros((4, 3), dtype=np.float64, order="F")
 
     pool, perm = make_pool(S1, S2)
-    R = tox_determine_shared_residual_range_expert(pool, perm, 95.0)
+    R = tox_determine_shared_residual_range_expert(pool, perm, 0.95)
     assert abs(R - 0.0) < TOL, f"Test 6 failed: expected 0.0, got {R}"
 
     # ============================================================
@@ -179,7 +179,7 @@ def test_tox_determine_shared_residual_range_expert():
     S2 = np.array([[-4.0]], dtype=np.float64, order="F")
 
     pool, perm = make_pool(S1, S2)
-    R = tox_determine_shared_residual_range_expert(pool, perm, 95.0)
+    R = tox_determine_shared_residual_range_expert(pool, perm, 0.95)
     assert abs(R - 3.95) < TOL, f"Test 7 failed: expected 3.95, got {R}"
 
 

--- a/python/test/mod_test_get_outliers.py
+++ b/python/test/mod_test_get_outliers.py
@@ -292,7 +292,7 @@ def test_identify_outliers_basic():
     # RDI values with clear outlier
     rdi = np.array([0.5, 0.6, 0.4, 3.5, 0.5], dtype=np.float64)
 
-    result = tox_identify_outliers(rdi, percentile=80.0)  # Use 80th percentile
+    result = tox_identify_outliers(rdi, percentile=0.8)  # Use 80th percentile
 
     # Verify that gene with RDI=3.5 is identified as outlier
     assert result['outliers'][3] == True
@@ -304,7 +304,7 @@ def test_identify_outliers_no_outliers():
 
     rdi = np.array([0.5, 0.6, 0.4, 0.7, 0.5], dtype=np.float64)  # All low RDI
 
-    result = tox_identify_outliers(rdi, percentile=99.0)  # Very high percentile
+    result = tox_identify_outliers(rdi, percentile=0.99)  # Very high percentile
 
     # With very high percentile, few or no outliers should be found
     assert isinstance(result['outliers'], np.ndarray)
@@ -316,7 +316,7 @@ def test_identify_outliers_all_outliers():
 
     rdi = np.array([3.0, 4.0, 5.0, 3.5], dtype=np.float64)  # All high RDI
 
-    result = tox_identify_outliers(rdi, percentile=25.0)  # Low percentile = more outliers
+    result = tox_identify_outliers(rdi, percentile=0.25)  # Low percentile = more outliers
 
     # With low percentile, more outliers should be found
     assert sum(result['outliers']) >= 1
@@ -346,7 +346,7 @@ def test_detect_outliers_pipeline():
         5, 5, 5, 5,  # Family 5
         6, 6, 6, 6   # Family 6
     ], dtype=np.int32)
-    percentile = 90.0
+    percentile = 0.9
 
     result = tox_detect_outliers(distances, gene_to_fam, percentile)
 
@@ -378,7 +378,7 @@ def test_detect_outliers_performance():
     import time
     start_time = time.time()
 
-    result = tox_detect_outliers(distances, gene_to_fam, percentile=95.0)
+    result = tox_detect_outliers(distances, gene_to_fam, percentile=0.95)
 
     end_time = time.time()
     elapsed = end_time - start_time
@@ -397,14 +397,14 @@ def test_detect_outliers_edge_cases():
     distances = np.array([1.0, 2.0, 3.0], dtype=np.float64)
     gene_to_fam = np.array([1, 1, 1], dtype=np.int32)
 
-    result = tox_detect_outliers(distances, gene_to_fam, percentile=95.0)
+    result = tox_detect_outliers(distances, gene_to_fam, percentile=0.95)
     assert len(result['loess_x']) == 1
 
     # Case 2: Each gene in different family
     distances = np.array([1.0, 2.0, 3.0], dtype=np.float64)
     gene_to_fam = np.array([1, 2, 3], dtype=np.int32)
 
-    result = tox_detect_outliers(distances, gene_to_fam, percentile=95.0)
+    result = tox_detect_outliers(distances, gene_to_fam, percentile=0.95)
     assert len(result['loess_x']) == 3
 
 

--- a/rcpp/tensoromics_functions.R
+++ b/rcpp/tensoromics_functions.R
@@ -167,7 +167,7 @@ tox_calculate_tissue_versatility <- function(expression_vectors, vector_selectio
 #' @param distances Numeric vector of gene distances
 #' @param gene_to_fam Integer vector mapping genes to family indices
 #' @param n_families Integer number of families
-#' @param percentile Percentile threshold for outlier detection (default: 95.0)
+#' @param percentile Percentile threshold in [0,1] for outlier detection (default: 0.95)
 #' @return A list with:
 #' \describe{
 #'   \item{is_outlier}{Logical vector indicating outliers}
@@ -177,7 +177,7 @@ tox_calculate_tissue_versatility <- function(expression_vectors, vector_selectio
 #'   \item{quantile}{Numeric vector of empirical quantiles (effect-size measure) per gene}
 #'   \item{ierr}{Integer status code from backend routine}
 #' }
-tox_detect_outliers <- function(distances, gene_to_fam, n_families, percentile = 95.0) {
+tox_detect_outliers <- function(distances, gene_to_fam, n_families, percentile = 0.95) {
 
   # Input Validation
   validate_numeric_vector(distances)
@@ -351,14 +351,14 @@ tox_compute_rdi <- function(distances, gene_to_fam, dscale) {
 #' against a percentile threshold of the sorted RDI distribution.
 #'
 #' @param rdi Numeric vector of RDI values
-#' @param percentile Percentile threshold (default: 95.0)
+#' @param percentile Percentile threshold in [0,1] (default: 0.95)
 #' @return A list with:
 #' \describe{
 #'   \item{is_outlier}{Logical vector indicating outliers}
 #'   \item{threshold}{Numeric RDI threshold value used}
 #'   \item{quantile}{Numeric vector of empirical quantiles (effect-size measure) per gene}
 #' }
-tox_identify_outliers <- function(rdi, percentile = 95.0) {
+tox_identify_outliers <- function(rdi, percentile = 0.95) {
 
   # Input Validation
   validate_numeric_vector(rdi)

--- a/rcpp/tensoromics_functions.R
+++ b/rcpp/tensoromics_functions.R
@@ -1193,11 +1193,11 @@ tox_mean_vector <- function(expression_vectors, gene_indices) {
 #'
 #' @param residual_pool Numeric vector of absolute residuals (NaNs removed)
 #' @param residual_pool_perm Integer vector giving the permutation that sorts `residual_pool`
-#' @param residual_range_quantile Numeric scalar (default 95.0)
+#' @param residual_range_quantile Numeric scalar, quantile in [0,1] (default 0.95)
 #'
 #' @return Numeric scalar: the shared residual range R
 #'
-tox_determine_shared_residual_range_expert <- function(residual_pool, residual_pool_perm, residual_range_quantile = 95.0) {
+tox_determine_shared_residual_range_expert <- function(residual_pool, residual_pool_perm, residual_range_quantile = 0.95) {
   # Input Validation
   validate_numeric_vector(residual_pool)
   validate_integer_vector(residual_pool_perm)
@@ -1227,11 +1227,11 @@ tox_determine_shared_residual_range_expert <- function(residual_pool, residual_p
 #'
 #' @param neighborhood_residuals_S1 Numeric array (n_reps x n_neighbors x n_points)
 #' @param neighborhood_residuals_S2 Numeric array (n_reps x n_neighbors x n_points)
-#' @param residual_range_quantile Numeric scalar (default 95.0)
+#' @param residual_range_quantile Numeric scalar, quantile in [0,1] (default 0.95)
 #'
 #' @return Numeric scalar: the shared residual range R
 #'
-tox_determine_shared_residual_range <- function(neighborhood_residuals_S1, neighborhood_residuals_S2, residual_range_quantile = 95.0) {
+tox_determine_shared_residual_range <- function(neighborhood_residuals_S1, neighborhood_residuals_S2, residual_range_quantile = 0.95) {
   # Input Validation
   validate_numeric_array(neighborhood_residuals_S1)
   validate_numeric_array(neighborhood_residuals_S2)

--- a/rcpp/test/mod_test_data_integration_jsd.R
+++ b/rcpp/test/mod_test_data_integration_jsd.R
@@ -22,11 +22,11 @@ test_determine_shared_residual_range <- function() {
     9,0,1,2
   ), dim = c(3, 2, 2))
 
-  R <- tox_determine_shared_residual_range(S1, S2, 95)
+  R <- tox_determine_shared_residual_range(S1, S2, 0.95)
   assert_true(approx_equal(R, 10.65), "Test 1 failed: expected ~10.65")
 
   # Test 2 — Custom quantile
-  R <- tox_determine_shared_residual_range(S1, S2, 50)
+  R <- tox_determine_shared_residual_range(S1, S2, 0.5)
   assert_true(approx_equal(R, 4.0), "Test 2 failed: expected ~4.0")
 
   # Test 3 — Quantile < 0 → error
@@ -35,10 +35,10 @@ test_determine_shared_residual_range <- function() {
     "Test 3 failed: expected error for negative quantile"
   )
 
-  # Test 4 — Quantile > 100 → error
+  # Test 4 — Quantile > 1 → error
   assert_error(
-    tox_determine_shared_residual_range(S1, S2, 150),
-    "Test 4 failed: expected error for quantile > 100"
+    tox_determine_shared_residual_range(S1, S2, 1.5),
+    "Test 4 failed: expected error for quantile > 1"
   )
 
   # Test 5 — NaNs ignored
@@ -56,19 +56,19 @@ test_determine_shared_residual_range <- function() {
     9,10,NA_real_
   ), dim = c(3,2,2))
 
-  R <- tox_determine_shared_residual_range(S1, S2, 95)
+  R <- tox_determine_shared_residual_range(S1, S2, 0.95)
   assert_true(approx_equal(R, 11.0), "Test 5 failed: expected ~11.0")
 
   # Test 6 — All zeros
   S1 <- array(0, dim = c(4,2,2))
   S2 <- array(0, dim = c(3,2,2))
-  R <- tox_determine_shared_residual_range(S1, S2, 95)
+  R <- tox_determine_shared_residual_range(S1, S2, 0.95)
   assert_true(approx_equal(R, 0.0), "Test 6 failed: expected 0")
 
   # Test 7 — Single residual
   S1 <- array(3, dim = c(1, 1, 1))
   S2 <- array(-4, dim = c(1, 1, 1))
-  R <- tox_determine_shared_residual_range(S1, S2, 95)
+  R <- tox_determine_shared_residual_range(S1, S2, 0.95)
   assert_true(approx_equal(R, 3.95), "Test 7 failed: expected ~3.95")
 }
 
@@ -98,11 +98,11 @@ test_determine_shared_residual_range_expert <- function() {
   pp <- make_pool(S1, S2)
 
   # Test 1
-  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 95)
+  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 0.95)
   assert_true(approx_equal(R, 10.65), "Test 1 failed")
 
   # Test 2
-  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 50)
+  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 0.5)
   assert_true(approx_equal(R, 4.0), "Test 2 failed")
 
   # Test 3
@@ -113,7 +113,7 @@ test_determine_shared_residual_range_expert <- function() {
 
   # Test 4
   assert_error(
-    tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 150),
+    tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 1.5),
     "Test 4 failed"
   )
 
@@ -133,21 +133,21 @@ test_determine_shared_residual_range_expert <- function() {
   ), dim = c(3,2,2))
 
   pp <- make_pool(S1, S2)
-  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 95)
+  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 0.95)
   assert_true(approx_equal(R, 11.0), "Test 5 failed")
 
   # Test 6 — All zeros
   S1 <- array(0, dim = c(4,2,2))
   S2 <- array(0, dim = c(3,2,2))
   pp <- make_pool(S1, S2)
-  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 95)
+  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 0.95)
   assert_true(approx_equal(R, 0.0), "Test 6 failed")
 
   # Test 7 — Single residual
   S1 <- array(3, dim = c(1, 1, 1))
   S2 <- array(-4, dim = c(1, 1, 1))
   pp <- make_pool(S1, S2)
-  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 95)
+  R <- tox_determine_shared_residual_range_expert(pp$pool, pp$perm, 0.95)
   assert_true(approx_equal(R, 3.95), "Test 7 failed")
 }
 

--- a/rcpp/test/mod_test_get_outliers.R
+++ b/rcpp/test/mod_test_get_outliers.R
@@ -153,7 +153,7 @@ test_compute_rdi_negative_distances <- function() {
 # Test 9: Simple outlier identification
 test_identify_outliers_simple <- function() {
   rdi <- c(0.3, 0.1, 0.5, 0.2, 0.4)
-  percentile <- 50.0
+  percentile <- 0.5
   
   result <- tox_identify_outliers(rdi, percentile)
   
@@ -167,7 +167,7 @@ test_identify_outliers_simple <- function() {
 # Test 10: All zeros RDI
 test_identify_outliers_all_zeros <- function() {
   rdi <- c(0, 0, 0, 0, 0)
-  percentile <- 90.0
+  percentile <- 0.9
   
   result <- tox_identify_outliers(rdi, percentile)
   
@@ -192,7 +192,7 @@ test_identify_outliers_percentile_0 <- function() {
 # Test 12: Percentile 100 (minimal outliers)
 test_identify_outliers_percentile_100 <- function() {
   rdi <- c(0.3, 0.1, 0.5, 0.2, 0.4)
-  percentile <- 100.0
+  percentile <- 1.0
   
   result <- tox_identify_outliers(rdi, percentile)
   
@@ -212,7 +212,7 @@ test_detect_outliers_typical <- function() {
   n_families <- 8
   genes_per_fam <- 6
   n_genes <- n_families * genes_per_fam
-  percentile <- 80.0
+  percentile <- 0.8
 
   # Generate distances and gene-to-family mapping
   distances <- runif(n_genes, 1, 10)  # Random distances
@@ -233,7 +233,7 @@ test_detect_outliers_invalid_families <- function() {
   distances <- c(1, 2, 3, 4, 5, 6)
   gene_to_fam <- c(1, 3, 2, 2, 2, 2)  # family 3 doesn't exist
   n_families <- 2
-  percentile <- 80.0
+  percentile <- 0.8
   
   error_caught <- FALSE
   tryCatch({
@@ -252,7 +252,7 @@ test_detect_outliers_single_families <- function() {
   distances <- c(1, 10, 100)  # Each gene in different family
   gene_to_fam <- c(1, 2, 3)
   n_families <- 3
-  percentile <- 90.0
+  percentile <- 0.9
   
   result <- tox_detect_outliers(distances, gene_to_fam, n_families, percentile)
   
@@ -288,7 +288,7 @@ test_detect_outliers_mixed_sizes <- function() {
     rep(8, 5)    # Family 8
   )
   n_families <- 8
-  percentile <- 95.0
+  percentile <- 0.95
 
   result <- tox_detect_outliers(distances, gene_to_fam, n_families, percentile)
 
@@ -320,7 +320,7 @@ test_detect_outliers_large_dataset <- function() {
   # Map each distance to a family index. The constructed distances vector has
   # 10+10+10+10+10+10+10+10+2 = 92 elements, so create a matching mapping of length 92.
   gene_to_fam <- c(rep(1:10, each = 9), 9, 10)
-  percentile <- 90.0
+  percentile <- 0.9
 
   result <- tox_detect_outliers(distances, gene_to_fam, n_families, percentile)
   # Verify large dataset handling

--- a/src/f42/f42_utils.F90
+++ b/src/f42/f42_utils.F90
@@ -1357,7 +1357,7 @@ contains
         integer(int32), intent(in) :: permutation(:)
             !! permutation vector representing sorted order
         real(real64), intent(in) :: percentile
-            !! desired percentile (0-100)
+            !! desired percentile as a fraction in [0,1] (e.g. 0.95 for the 95th percentile)
         real(real64), intent(out) :: value
             !! output percentile value
         integer(int32), intent(out) :: ierr
@@ -1373,7 +1373,7 @@ contains
         call validate_dimension_size(n, ierr, arg_pos=2_int32)
         call validate_in_range_int(size(array, kind=int32), ierr, min=1_int32, max=n, arg_pos=1_int32)
         call validate_all_in_range_int(permutation, n, ierr, min=1_int32, max=size(array, kind=int32), arg_pos=2_int32)
-        call validate_in_range_real(percentile, ierr, min=0.0_real64, max=100.0_real64, arg_pos=3_int32)
+        call validate_in_range_real(percentile, ierr, min=0.0_real64, max=1.0_real64, arg_pos=3_int32)
 
         if (is_err(ierr)) return
 
@@ -1386,9 +1386,9 @@ contains
         integer(int32), intent(in) :: n
             !! Sample size
         real(real64), intent(in) :: percentile
-            !! desired percentile (0-100)
+            !! desired percentile as a fraction in [0,1] (e.g. 0.95 for the 95th percentile)
 
-        rank = (percentile/100.0_real64)*real(n - 1, real64) + 1.0_real64
+        rank = percentile*real(n - 1, real64) + 1.0_real64
     end function calc_percentile_rank
 
     !> AUTHOR_AARON_SCHROEDER
@@ -1400,7 +1400,7 @@ contains
         integer(int32), intent(in) :: permutation(:)
             !! permutation vector representing sorted order
         real(real64), intent(in) :: percentile
-            !! desired percentile (0-100)
+            !! desired percentile as a fraction in [0,1] (e.g. 0.95 for the 95th percentile)
         real(real64), intent(out) :: value
             !! output percentile value
 
@@ -1439,7 +1439,7 @@ contains
         real(real64), intent(in) :: array(:)
             !! Input array
         real(real64), intent(in) :: percentile
-            !! Desired percentile (0-100)
+            !! Desired percentile as a fraction in [0,1] (e.g. 0.95 for the 95th percentile)
         real(real64), intent(out) :: value
             !! Output percentile value
         integer(int32), intent(out) :: ierr
@@ -1453,7 +1453,7 @@ contains
         call set_ok(ierr)
 
         call validate_dimension_size(n, ierr, arg_pos=1_int32)
-        call validate_in_range_real(percentile, ierr, min=0.0_real64, max=100.0_real64, arg_pos=2_int32)
+        call validate_in_range_real(percentile, ierr, min=0.0_real64, max=1.0_real64, arg_pos=2_int32)
 
         if (is_err(ierr)) return
 

--- a/src/tox/data/integration/tox_data_integration.F90
+++ b/src/tox/data/integration/tox_data_integration.F90
@@ -429,7 +429,7 @@ module tox_data_integration
             integer(int32), intent(in) :: pool_size
                 !! Size of pool of residuals `abs_residual_pool`, usually `(n_reps_S1 + n_reps_2)*n_neighbors*n_points`
             real(real64), intent(in), optional :: residual_range_quantile
-                !! Quantile for determining the residual range, default: 95.0
+                !! Quantile in [0,1] for determining the residual range, default: 0.95
             real(real64), intent(out) :: shared_residual_range
                 !! Computed residual range (R)
             real(real64), dimension(pool_size), intent(in) :: abs_residual_pool
@@ -447,7 +447,7 @@ module tox_data_integration
             integer(int32), intent(in) :: pool_size
                 !! Size of pool of residuals `abs_residual_pool`, usually `(n_reps_S1 + n_reps_2)*n_neighbors*n_points`
             real(real64), intent(in), optional :: residual_range_quantile
-                !! Quantile for determining the residual range, default: 95.0
+                !! Quantile in [0,1] for determining the residual range, default: 0.95
             real(real64), intent(out) :: shared_residual_range
                 !! Computed residual range (R)
             real(real64), dimension(pool_size), intent(in) :: abs_residual_pool
@@ -473,7 +473,7 @@ module tox_data_integration
             real(real64), dimension(n_reps_S2, n_neighbors, n_points), intent(in) :: neighborhood_residuals_S2
                 !! Computed neighborhood residuals for study 2 ([[tox_data_integration(module):construct_neighborhoods(interface)]]), NaN is explicitly allowed for missing values
             real(real64), intent(in), optional :: residual_range_quantile
-                !! Quantile for determining the residual range, default: 95.0
+                !! Quantile in [0,1] for determining the residual range, default: 0.95
             real(real64), intent(out) :: shared_residual_range
                 !! Computed residual range (R)
             integer(int32), intent(out) :: ierr

--- a/src/tox/data/integration/tox_data_integration_jsd.F90
+++ b/src/tox/data/integration/tox_data_integration_jsd.F90
@@ -71,7 +71,9 @@ contains
             return
         end if
 
-        call calc_percentile_helper(abs_residual_pool, abs_residual_pool_perm(:last_non_nan), actual_quantile, shared_residual_range)
+        ! `residual_range_quantile` is a percentage in [0,100]; calc_percentile_helper expects a
+        ! fraction in [0,1], so convert here.
+        call calc_percentile_helper(abs_residual_pool, abs_residual_pool_perm(:last_non_nan), actual_quantile/100.0_real64, shared_residual_range)
     end subroutine determine_shared_residual_range_helper
 
     !> Computes the shared residual range [-R, R] for the computed residuals from studies S1 and S2

--- a/src/tox/data/integration/tox_data_integration_jsd.F90
+++ b/src/tox/data/integration/tox_data_integration_jsd.F90
@@ -17,7 +17,7 @@ contains
         integer(int32), intent(in) :: pool_size
             !! Size of pool of residuals `abs_residual_pool`, usually `(n_reps_S1 + n_reps_2)*n_neighbors*n_points`
         real(real64), intent(in), optional :: residual_range_quantile
-            !! Quantile for determining the residual range, default: 95.0
+            !! Quantile in [0,1] for determining the residual range, default: 0.95
         real(real64), intent(out) :: shared_residual_range
             !! Computed residual range (R)
         real(real64), dimension(pool_size), intent(in) :: abs_residual_pool
@@ -30,7 +30,7 @@ contains
         call set_ok(ierr)
 
         call validate_dimension_size(pool_size, ierr)
-        call validate_in_range_real(residual_range_quantile, ierr, min=0.0_real64, max=100.0_real64)
+        call validate_in_range_real(residual_range_quantile, ierr, min=0.0_real64, max=1.0_real64)
         call validate_all_in_range_int(abs_residual_pool_perm, pool_size, ierr, min=1_int32, max=pool_size)
 
         if (is_err(ierr)) return
@@ -43,7 +43,7 @@ contains
         integer(int32), intent(in) :: pool_size
             !! Size of pool of residuals `abs_residual_pool`, usually `(n_reps_S1 + n_reps_2)*n_neighbors*n_points`
         real(real64), intent(in), optional :: residual_range_quantile
-            !! Quantile for determining the residual range, default: 95.0
+            !! Quantile in [0,1] for determining the residual range, default: 0.95
         real(real64), intent(out) :: shared_residual_range
             !! Computed residual range (R)
         real(real64), dimension(pool_size), intent(in) :: abs_residual_pool
@@ -54,7 +54,7 @@ contains
         integer(int32) :: i_pool, last_non_nan
         real(real64) :: actual_quantile
 
-        M_DEFAULT_VAL(residual_range_quantile, actual_quantile, 95.0_real64)
+        M_DEFAULT_VAL(residual_range_quantile, actual_quantile, 0.95_real64)
 
         last_non_nan = pool_size
         ! NaN is always last -> find last non-NaN index for percentile calculation
@@ -71,9 +71,7 @@ contains
             return
         end if
 
-        ! `residual_range_quantile` is a percentage in [0,100]; calc_percentile_helper expects a
-        ! fraction in [0,1], so convert here.
-        call calc_percentile_helper(abs_residual_pool, abs_residual_pool_perm(:last_non_nan), actual_quantile/100.0_real64, shared_residual_range)
+        call calc_percentile_helper(abs_residual_pool, abs_residual_pool_perm(:last_non_nan), actual_quantile, shared_residual_range)
     end subroutine determine_shared_residual_range_helper
 
     !> Computes the shared residual range [-R, R] for the computed residuals from studies S1 and S2
@@ -91,7 +89,7 @@ contains
         real(real64), dimension(n_reps_S2, n_neighbors, n_points), intent(in) :: neighborhood_residuals_S2
             !! Computed neighborhood residuals for study 2 ([[tox_data_integration(module):construct_neighborhoods(interface)]]), NaN is explicitly allowed for missing values
         real(real64), intent(in), optional :: residual_range_quantile
-            !! Quantile for determining the residual range, default: 95.0
+            !! Quantile in [0,1] for determining the residual range, default: 0.95
         real(real64), intent(out) :: shared_residual_range
             !! Computed residual range (R)
         integer(int32), intent(out) :: ierr
@@ -466,7 +464,7 @@ pure subroutine determine_shared_residual_range_expert_c( &
     integer(c_int), intent(in), target :: pool_size
         !! Size of pool of residuals `abs_residual_pool`, usually `(n_reps_S1 + n_reps_2)*n_neighbors*n_points`
     real(c_double), intent(in), target :: residual_range_quantile
-        !! Quantile for determining the residual range, default: 95.0
+        !! Quantile in [0,1] for determining the residual range, default: 0.95
     real(c_double), intent(out), target :: shared_residual_range
         !! Computed residual range (R)
     real(c_double), dimension(pool_size), intent(in), target :: abs_residual_pool
@@ -515,7 +513,7 @@ pure subroutine determine_shared_residual_range_c( &
     real(c_double), dimension(n_reps_S2, n_neighbors, n_points), intent(in), target :: neighborhood_residuals_S2
         !! Computed neighborhood residuals for study 2 ([[tox_data_integration(module):construct_neighborhoods(interface)]]), NaN is explicitly allowed for missing values
     real(c_double), intent(in), target :: residual_range_quantile
-        !! Quantile for determining the residual range, default: 95.0
+        !! Quantile in [0,1] for determining the residual range, default: 0.95
     real(c_double), intent(out), target :: shared_residual_range
         !! Computed residual range (R)
     integer(c_int), intent(out), target :: ierr

--- a/src/tox/data/integration/tox_data_integration_preprocessing.F90
+++ b/src/tox/data/integration/tox_data_integration_preprocessing.F90
@@ -232,7 +232,8 @@ contains
         else
             ! Compute reference points as empirical quantiles using the permutation
             do concurrent(i_point=1:n_points) local(quantile_level) shared(n_points, pooled_means, pooled_means_perm, n_pool, x_star)
-                quantile_level = real(i_point, real64)/real(n_points + 1, real64)*100.0_real64
+                ! Fraction in [0,1] as expected by calc_percentile_helper
+                quantile_level = real(i_point, real64)/real(n_points + 1, real64)
 
                 ! Use calc_percentile to compute the value
                 call calc_percentile_helper(pooled_means, pooled_means_perm(:n_pool), quantile_level, x_star(i_point))

--- a/src/tox/tox_get_outliers.F90
+++ b/src/tox/tox_get_outliers.F90
@@ -168,7 +168,7 @@ contains
         ! Use the 5th percentile of the family means as a data-driven pseudo-count instead of a fixed
         ! constant, so log2(mean + eps_mean) below stays well-scaled across datasets with very
         ! different absolute expression ranges.
-        call calc_percentile(loess_x(1:n_valid), tmp_perm(1:n_valid), 5.0_real64, eps_mean, ierr)
+        call calc_percentile(loess_x(1:n_valid), tmp_perm(1:n_valid), 0.05_real64, eps_mean, ierr)
         if (is_err(ierr)) return
 
         eps_mean = max(eps_mean, EPS_LOESS)
@@ -207,7 +207,7 @@ contains
         call sort_array(loess_y(1:n_valid), tmp_perm(1:n_valid), tmp_stack_left(1:n_valid), tmp_stack_right(1:n_valid))
         ! Bottom 1% of (log2) stddevs is treated as "too flat to trust": these families would otherwise
         ! anchor the mean-vs-stddev LOESS curve with near-degenerate (close to zero-variance) points.
-        call calc_percentile(loess_y(1:n_valid), tmp_perm(1:n_valid), 1.0_real64, low_sd_cutoff, ierr)
+        call calc_percentile(loess_y(1:n_valid), tmp_perm(1:n_valid), 0.01_real64, low_sd_cutoff, ierr)
 
         if (is_err(ierr)) return
 

--- a/src/tox/tox_get_outliers.F90
+++ b/src/tox/tox_get_outliers.F90
@@ -489,7 +489,7 @@ contains
         real(real64), intent(out) :: threshold
             !! Output threshold value used for detection
         real(real64), intent(in), optional :: percentile
-            !! (optional) Percentile threshold (default: 95 for top 5%)
+            !! (optional) Percentile threshold as a fraction in [0,1] (default: 0.95 for top 5%)
         real(real64), intent(out) :: quantile(n_genes)
             !! Empirical one-sided upper-tail quantile (effect-size measure) for each gene, i.e. how extreme an
             !! observed distance is relative to all observed distances -- NOT a null-hypothesis-testing p-value.
@@ -503,7 +503,7 @@ contains
         if (present(percentile)) then
             percentile_val = percentile
         else
-            percentile_val = 95.0_real64
+            percentile_val = 0.95_real64
         end if
 
         ! Initialize output
@@ -518,8 +518,8 @@ contains
 
         ! Nearest-rank percentile: round the fractional rank up to the next integer index into the
         ! ascending-sorted array, so `threshold` is always an observed RDI value rather than an
-        ! interpolated one.
-        perc_pos = (n_genes*percentile_val)/100.0_real64
+        ! interpolated one. `percentile_val` is a fraction in [0,1].
+        perc_pos = n_genes*percentile_val
         idx = ceiling(perc_pos)
         ! Clamp idx to valid range
         if (idx < 1) idx = 1
@@ -574,7 +574,7 @@ contains
         integer(int32), intent(out) :: ierr
             !! Error code
         real(real64), intent(in), optional :: percentile
-            !! (optional) Percentile threshold for outlier detection (default: 95)
+            !! (optional) Percentile threshold in [0,1] for outlier detection (default: 0.95)
         real(real64), intent(out) :: quantile(n_genes)
             !! Empirical one-sided upper-tail quantile (effect-size measure) for each gene, i.e. how extreme an
             !! observed distance is relative to all observed distances -- NOT a null-hypothesis-testing p-value.
@@ -592,7 +592,7 @@ contains
         if (present(percentile)) then
             percentile_val = percentile
         else
-            percentile_val = 95.0_real64
+            percentile_val = 0.95_real64
         end if
 
         ! Always initialize permutation array
@@ -723,7 +723,7 @@ subroutine identify_outliers_c(n_genes, rdi, sorted_rdi, perm, is_outlier, thres
     real(c_double), intent(out), target :: threshold
         !! Output threshold value used for detection
     real(c_double), intent(in), target :: percentile
-        !! Percentile threshold for outlier detection
+        !! Percentile threshold as a fraction in [0,1] for outlier detection
     real(c_double), intent(out), target :: quantile(n_genes)
         !! Empirical one-sided upper-tail quantile (effect-size measure) for each gene, i.e. how extreme an
         !! observed distance is relative to all observed distances -- NOT a null-hypothesis-testing p-value.
@@ -799,7 +799,7 @@ subroutine detect_outliers_c(n_genes, n_families, distances, gene_to_fam, &
     integer(c_int), intent(out), target :: ierr
         !! Error code
     real(c_double), intent(in), target :: percentile
-        !! Percentile threshold for outlier detection
+        !! Percentile threshold as a fraction in [0,1] for outlier detection
 
     logical, dimension(:), allocatable :: is_outlier_f
 

--- a/test/mod_test_data_integration.F90
+++ b/test/mod_test_data_integration.F90
@@ -318,12 +318,12 @@ contains
         call assert_equal_real(R, 10.65_real64, TOL, "test_determine_shared_residual_range: Test 1: R should be 10.65")
 
         ! ============================================================
-        ! Test 2 — Custom quantile (50%)
+        ! Test 2 — Custom quantile (median, q=0.5)
         ! ============================================================
         !
         ! Median of sorted array above = 0.5 * (sorted(12) + sorted(13)) = 5.5
         !
-        q = 50.0_real64
+        q = 0.5_real64
         call determine_shared_residual_range_alloc(S1, S2, n_reps_S1, n_reps_S2, n_neighbors, n_points, R, ierr, q)
         call assert_equal_int(ierr, ERR_OK, "test_determine_shared_residual_range: Test 2: ierr should be OK")
         call assert_equal_real(R, 4.0_real64, TOL, "test_determine_shared_residual_range: Test 2: R should be 4.0")
@@ -336,9 +336,9 @@ contains
         call assert_equal_int(ierr, ERR_INVALID_INPUT, "test_determine_shared_residual_range: Test 3: ierr should be INVALID_INPUT")
 
         ! ============================================================
-        ! Test 4 — Quantile > 100 → error
+        ! Test 4 — Quantile > 1 → error
         ! ============================================================
-        q = above(100.0_real64)
+        q = above(1.0_real64)
         call determine_shared_residual_range_alloc(S1, S2, n_reps_S1, n_reps_S2, n_neighbors, n_points, R, ierr, q)
         call assert_equal_int(ierr, ERR_INVALID_INPUT, "test_determine_shared_residual_range: Test 4: ierr should be INVALID_INPUT")
 

--- a/test/mod_test_get_outliers.F90
+++ b/test/mod_test_get_outliers.F90
@@ -271,7 +271,7 @@ contains
     ! values ascending: 0.1 (idx2), 0.2 (idx4), 0.3 (idx1), 0.4 (idx3)
     perm = [2_int32, 4_int32, 1_int32, 3_int32]
 
-    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 75.0_real64)
+    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 0.75_real64)
 
     ! percentile 75%: idx = ceil(4*0.75)=3
     ! threshold = sorted_rdi(perm(3)) = sorted_rdi(1) = 0.3
@@ -349,7 +349,7 @@ contains
     sorted_rdi = rdi
     perm = [1_int32, 2_int32, 3_int32, 4_int32]
 
-    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 100.0_real64)
+    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 1.0_real64)
 
     call assert_equal_real(threshold, 0.4_real64, 1d-12, "Percentile 100 -> threshold must be maximum")
     call assert_false(any(is_outlier(1:3)), "No outliers below maximum at 100 percentile")
@@ -389,7 +389,7 @@ contains
     call assert_equal_real(quantile(4), 2.0_real64/denom, 1d-12, "quantile(d=4)=0.4")
 
     ! Percentile 100 -> threshold = maximum (4.0)
-    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 100.0_real64)
+    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 1.0_real64)
     call assert_equal_real(threshold, 4.0_real64, 1d-12, "p=100 -> threshold=max")
     call assert_false(any(is_outlier(1:3)), "Values below max not outliers at percentile 100")
     call assert_true(is_outlier(4), "Max value is outlier at percentile 100")
@@ -418,7 +418,7 @@ contains
     perm = [1_int32, 2_int32, 3_int32, 4_int32]
 
     ! percentile 50 -> idx = ceil(4*0.5)=2 -> threshold = second smallest = 2.0
-    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 50.0_real64)
+    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 0.5_real64)
 
     call assert_equal_real(threshold, 2.0_real64, 1d-12, "Threshold must be 2.0 at 50 percentile")
     call assert_true(is_outlier(2), "First 2.0 must be outlier")
@@ -482,7 +482,7 @@ contains
     ! All values equal (0). Any perm is fine.
     perm = [1_int32, 2_int32, 3_int32, 4_int32, 5_int32]
 
-    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 80.0_real64)
+    call identify_outliers(n_genes, rdi, sorted_rdi, perm, is_outlier, threshold, quantile, 0.8_real64)
 
     call assert_equal_real(threshold, 0.0_real64, 1d-12, "All-negative -> clamped distribution -> threshold 0")
     call assert_true(.not. any(is_outlier), "All-negative RDI should not be outliers")
@@ -1000,12 +1000,12 @@ contains
     end do
     distances(n_genes) = 500.0_real64
 
-    ! percentile=90: threshold at the 90th percentile; with n=12, this typically isolates the largest value
+    ! percentile=0.9: threshold at the 90th percentile; with n=12, this typically isolates the largest value
     perm = [(i, i=1,n_genes)]
     call detect_outliers( &
                          n_genes, n_families, distances, gene_to_fam, work_rdi, &
                          perm, sl, sr, is_outlier, lx, ly, ln, quantile, ierr, &
-                         percentile=90.0_real64)
+                         percentile=0.9_real64)
 
     call assert_equal_int(ierr, 0, "Error code 0 (test_outliers_extreme_detection)")
     call assert_true(is_outlier(12), "The extreme gene (12) should be an outlier")

--- a/test/mod_test_percentile.F90
+++ b/test/mod_test_percentile.F90
@@ -1,0 +1,187 @@
+!> Unit test suite for the calc_percentile family (f42_utils).
+!|
+!| These tests pin the contract introduced by issue #149: the `percentile`
+!| argument is a fraction/probability in the statistical interval [0,1]
+!| (e.g. 0.95 for the 95th percentile), NOT a percentage in [0,100].
+module mod_test_percentile
+    use asserts
+    use f42_utils
+    use tox_errors
+    use, intrinsic :: iso_fortran_env, only: real64, int32
+    use test_suite, only: test_case
+    implicit none
+    public
+
+    real(real64), parameter :: TOL = 1d-12
+
+contains
+
+    !> Get array of all available percentile tests.
+    function get_all_tests_percentile() result(all_tests)
+        type(test_case), allocatable :: all_tests(:)
+        allocate (all_tests(8))
+        all_tests(1) = test_case("test_percentile_min_max_median", test_percentile_min_max_median)
+        all_tests(2) = test_case("test_percentile_interpolation", test_percentile_interpolation)
+        all_tests(3) = test_case("test_percentile_single_element", test_percentile_single_element)
+        all_tests(4) = test_case("test_percentile_rejects_percent_scale", test_percentile_rejects_percent_scale)
+        all_tests(5) = test_case("test_percentile_boundaries_inclusive", test_percentile_boundaries_inclusive)
+        all_tests(6) = test_case("test_percentile_alloc_unsorted", test_percentile_alloc_unsorted)
+        all_tests(7) = test_case("test_percentile_alloc_rejects_percent_scale", test_percentile_alloc_rejects_percent_scale)
+        all_tests(8) = test_case("test_percentile_helper_interpolation", test_percentile_helper_interpolation)
+    end function get_all_tests_percentile
+
+    !> A fraction in [0,1] must map min -> 0.0, max -> 1.0, median -> 0.5.
+    subroutine test_percentile_min_max_median()
+        real(real64) :: array(5) = [10.0_real64, 20.0_real64, 30.0_real64, 40.0_real64, 50.0_real64]
+        integer(int32) :: perm(5)
+        real(real64) :: value
+        integer(int32) :: ierr
+
+        ! array is already sorted -> identity permutation is the sorting order
+        call init_perm(perm)
+
+        call calc_percentile(array, perm, 0.0_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_min_max_median: p=0.0 ierr should be OK")
+        call assert_equal_real(value, 10.0_real64, TOL, "test_percentile_min_max_median: p=0.0 should return the minimum")
+
+        call calc_percentile(array, perm, 0.5_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_min_max_median: p=0.5 ierr should be OK")
+        call assert_equal_real(value, 30.0_real64, TOL, "test_percentile_min_max_median: p=0.5 should return the median")
+
+        call calc_percentile(array, perm, 1.0_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_min_max_median: p=1.0 ierr should be OK")
+        call assert_equal_real(value, 50.0_real64, TOL, "test_percentile_min_max_median: p=1.0 should return the maximum")
+    end subroutine test_percentile_min_max_median
+
+    !> Linear interpolation between adjacent sorted values for fractional ranks.
+    subroutine test_percentile_interpolation()
+        real(real64) :: array(5) = [10.0_real64, 20.0_real64, 30.0_real64, 40.0_real64, 50.0_real64]
+        integer(int32) :: perm(5)
+        real(real64) :: value
+        integer(int32) :: ierr
+
+        call init_perm(perm)
+
+        ! rank = p*(n-1)+1 with n=5
+        ! p=0.10 -> rank=1.4 -> 10 + 0.4*(20-10) = 14
+        call calc_percentile(array, perm, 0.10_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_interpolation: p=0.10 ierr should be OK")
+        call assert_equal_real(value, 14.0_real64, TOL, "test_percentile_interpolation: p=0.10 should interpolate to 14.0")
+
+        ! p=0.25 -> rank=2.0 -> exactly 20
+        call calc_percentile(array, perm, 0.25_real64, value, ierr)
+        call assert_equal_real(value, 20.0_real64, TOL, "test_percentile_interpolation: p=0.25 should be 20.0")
+
+        ! p=0.95 -> rank=4.8 -> 40 + 0.8*(50-40) = 48
+        call calc_percentile(array, perm, 0.95_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_interpolation: p=0.95 ierr should be OK")
+        call assert_equal_real(value, 48.0_real64, TOL, "test_percentile_interpolation: p=0.95 should interpolate to 48.0")
+    end subroutine test_percentile_interpolation
+
+    !> A single-element array returns that element for any percentile.
+    subroutine test_percentile_single_element()
+        real(real64) :: array(1) = [42.0_real64]
+        integer(int32) :: perm(1)
+        real(real64) :: value
+        integer(int32) :: ierr
+
+        call init_perm(perm)
+
+        call calc_percentile(array, perm, 0.0_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_single_element: p=0.0 ierr should be OK")
+        call assert_equal_real(value, 42.0_real64, TOL, "test_percentile_single_element: p=0.0 should return the only element")
+
+        call calc_percentile(array, perm, 0.73_real64, value, ierr)
+        call assert_equal_real(value, 42.0_real64, TOL, "test_percentile_single_element: p=0.73 should return the only element")
+    end subroutine test_percentile_single_element
+
+    !> Regression proof for issue #149: values on the old [0,100] percent
+    !| scale (or otherwise outside [0,1]) must now be rejected as out of range.
+    subroutine test_percentile_rejects_percent_scale()
+        real(real64) :: array(5) = [10.0_real64, 20.0_real64, 30.0_real64, 40.0_real64, 50.0_real64]
+        integer(int32) :: perm(5)
+        real(real64) :: value
+        integer(int32) :: ierr
+
+        call init_perm(perm)
+
+        ! 50.0 used to mean "the median"; on the [0,1] scale it is out of range.
+        call calc_percentile(array, perm, 50.0_real64, value, ierr)
+        call assert_equal_int(ierr, create_err_code(ERR_INVALID_INPUT, arg_pos=3_int32), &
+                              "test_percentile_rejects_percent_scale: 50.0 must be rejected (arg 3 out of range)")
+
+        ! Just above the upper bound.
+        call calc_percentile(array, perm, above(1.0_real64), value, ierr)
+        call assert_equal_int(ierr, create_err_code(ERR_INVALID_INPUT, arg_pos=3_int32), &
+                              "test_percentile_rejects_percent_scale: >1 must be rejected (arg 3 out of range)")
+
+        ! Just below the lower bound.
+        call calc_percentile(array, perm, below(0.0_real64), value, ierr)
+        call assert_equal_int(ierr, create_err_code(ERR_INVALID_INPUT, arg_pos=3_int32), &
+                              "test_percentile_rejects_percent_scale: <0 must be rejected (arg 3 out of range)")
+    end subroutine test_percentile_rejects_percent_scale
+
+    !> The [0,1] interval is inclusive: exactly 0.0 and 1.0 are valid.
+    subroutine test_percentile_boundaries_inclusive()
+        real(real64) :: array(4) = [-1.0_real64, 0.0_real64, 2.0_real64, 5.0_real64]
+        integer(int32) :: perm(4)
+        real(real64) :: value
+        integer(int32) :: ierr
+
+        call init_perm(perm)
+
+        call calc_percentile(array, perm, 0.0_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_boundaries_inclusive: 0.0 must be accepted")
+        call assert_equal_real(value, -1.0_real64, TOL, "test_percentile_boundaries_inclusive: p=0.0 returns minimum")
+
+        call calc_percentile(array, perm, 1.0_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_boundaries_inclusive: 1.0 must be accepted")
+        call assert_equal_real(value, 5.0_real64, TOL, "test_percentile_boundaries_inclusive: p=1.0 returns maximum")
+    end subroutine test_percentile_boundaries_inclusive
+
+    !> calc_percentile_alloc sorts internally, so it accepts unsorted input and
+    !| honours the same [0,1] contract.
+    subroutine test_percentile_alloc_unsorted()
+        real(real64) :: array(5) = [30.0_real64, 10.0_real64, 50.0_real64, 20.0_real64, 40.0_real64]
+        real(real64) :: value
+        integer(int32) :: ierr
+
+        call calc_percentile_alloc(array, 0.5_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_alloc_unsorted: p=0.5 ierr should be OK")
+        call assert_equal_real(value, 30.0_real64, TOL, "test_percentile_alloc_unsorted: p=0.5 should return the median")
+
+        call calc_percentile_alloc(array, 0.95_real64, value, ierr)
+        call assert_equal_int(ierr, ERR_OK, "test_percentile_alloc_unsorted: p=0.95 ierr should be OK")
+        call assert_equal_real(value, 48.0_real64, TOL, "test_percentile_alloc_unsorted: p=0.95 should interpolate to 48.0")
+    end subroutine test_percentile_alloc_unsorted
+
+    !> calc_percentile_alloc must also reject percent-scale input (arg 2).
+    subroutine test_percentile_alloc_rejects_percent_scale()
+        real(real64) :: array(5) = [30.0_real64, 10.0_real64, 50.0_real64, 20.0_real64, 40.0_real64]
+        real(real64) :: value
+        integer(int32) :: ierr
+
+        call calc_percentile_alloc(array, 95.0_real64, value, ierr)
+        call assert_equal_int(ierr, create_err_code(ERR_INVALID_INPUT, arg_pos=2_int32), &
+                              "test_percentile_alloc_rejects_percent_scale: 95.0 must be rejected (arg 2 out of range)")
+    end subroutine test_percentile_alloc_rejects_percent_scale
+
+    !> The unchecked helper produces the same interpolated values for a
+    !| caller-supplied sorted permutation.
+    subroutine test_percentile_helper_interpolation()
+        real(real64) :: array(5) = [10.0_real64, 20.0_real64, 30.0_real64, 40.0_real64, 50.0_real64]
+        integer(int32) :: perm(5)
+        real(real64) :: value
+
+        call init_perm(perm)
+
+        ! p=0.75 -> rank=4.0 -> exactly 40
+        call calc_percentile_helper(array, perm, 0.75_real64, value)
+        call assert_equal_real(value, 40.0_real64, TOL, "test_percentile_helper_interpolation: p=0.75 should be 40.0")
+
+        ! p=0.5 -> rank=3.0 -> exactly 30 (median)
+        call calc_percentile_helper(array, perm, 0.5_real64, value)
+        call assert_equal_real(value, 30.0_real64, TOL, "test_percentile_helper_interpolation: p=0.5 should be 30.0")
+    end subroutine test_percentile_helper_interpolation
+
+end module mod_test_percentile

--- a/test/run_tests.F90
+++ b/test/run_tests.F90
@@ -3,6 +3,7 @@ program main
     use, intrinsic :: iso_fortran_env, only: int32
     use test_suite
     use mod_test_compute_edf, only: get_all_tests_compute_edf
+    use mod_test_percentile, only: get_all_tests_percentile
     use mod_test_bst, only: get_all_tests_bst
     use mod_test_kd_tree, only: get_all_tests_kd_tree
     use mod_test_sorting, only: get_all_tests_sorting
@@ -43,6 +44,7 @@ program main
     call initialize_suites()
     call add_suite("bst", get_all_tests_bst)
     call add_suite("compute_edf", get_all_tests_compute_edf)
+    call add_suite("percentile", get_all_tests_percentile)
     call add_suite("kd_tree", get_all_tests_kd_tree)
     call add_suite("sorting", get_all_tests_sorting)
     call add_suite("get_outliers", get_all_tests_get_outliers)


### PR DESCRIPTION
Closes #149.

## What

Every percentile/quantile argument in the framework now takes a probability/quantile in the statistical interval **[0,1]** instead of a percentage in [0,100]. There are **no `/100` conversions left anywhere** in the codebase (verified by audit).

Three distinct public arguments were converted, plus the internal `calc_percentile` family:

1. **`calc_percentile` family** (`f42_utils`) — the routine named in the issue
2. **`residual_range_quantile`** (`determine_shared_residual_range` in the JSD module)
3. **`percentile`** of `identify_outliers` / `detect_outliers`

## Commits (one logical case per commit, per layer)

| Commit | Scope |
|--------|-------|
| Change calc_percentile range | `calc_percentile` / `_alloc` / `_helper` / `_rank`: validation `100→1`, drop `/100` in the rank formula, docs; + 4 direct callers (`tox_get_outliers` `5.0→0.05`/`1.0→0.01`, `preprocessing` drop `·100`, `jsd` hand-off) |
| Add calc_percentile unit tests | new `test/mod_test_percentile.F90` (8 tests): min/median/max, interpolation, inclusive [0,1] boundaries, `_alloc` on unsorted input, and a **regression test that old percent-scale values (50.0, 95.0) are now rejected** |
| residual_range_quantile → [0,1] | Fortran (validation `100→1`, default `95.0→0.95`, remove the interim `/100` hand-off), then Python wrapper+test, then R wrapper+test |
| identify/detect_outliers → [0,1] | Fortran (defaults `95.0→0.95`, `perc_pos = n·percentile`, C-binding docs), then Python wrapper+test, then R wrapper+test |

## Verification that percentile-dependent implementations are ported correctly

All numeric results are **unchanged** — a fraction `p` reproduces the previous `100·p` percentage exactly. This is backed by existing value-pinning tests that pass with the converted inputs:
- `test_determine_shared_residual_range`: R = 10.65 (0.95), 4.0 (q=0.5), 11.0, 3.95; out-of-range now probes `above(1.0)`.
- `test_pool_means_alloc_basic`: x_star = 3.25 / 5.5 / 7.75.
- `get_outliers` suite: thresholds at 0.75 / 1.0 / 0.5 / 0.9 nearest-rank positions.

## Testing

`bash run_all_tests.sh` — the complete framework is green:
- Fortran: all 33 suites pass with gfortran (incl. the new `percentile` suite).
- Python: all 24 test files `success`.
- R: all 25 test files `success`.

Ford-generated `doc/` and `snippets/` regenerate from the updated source comments; not hand-edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)