### PR TITLE
Audit shared-ierr in do concurrent loops; parallelize log-transform loops (#158)

### DIFF
--- a/src/f42/f42_utils.F90
+++ b/src/f42/f42_utils.F90
@@ -257,12 +257,30 @@ contains
 
         if (is_err(ierr)) return
 
+        call logx_helper(val, base, exponent)
+    end subroutine logx
+
+    !> AUTHOR_FRANZ_ERIC_SILL
+    !| (no input validation) Compute logarithm for any base: `log_base(val) = log(val)/log(base)`.
+    !| This is the non-validating core of [[f42_utils(module):logx(subroutine)]], split out so it can
+    !| be called from inside `do concurrent` loops without a shared `ierr` (which would be a data
+    !| race). The caller is responsible for guaranteeing valid inputs beforehand -- `val > 0`,
+    !| `base > 0` and `base /= 1` -- e.g. via an up-front [[tox_errors(module):validate_in_range_real(subroutine)]]
+    !| pass; violating them yields a NaN/Inf result instead of an error code.
+    pure subroutine logx_helper(val, base, exponent)
+        real(real64), intent(in) :: val
+            !! Value (`x` in \( b^y = x \)), must be `> 0`
+        real(real64), intent(in) :: base
+            !! Base (`b` in \( b^y = x \)), must be `> 0` and `/= 1`
+        real(real64), intent(out) :: exponent
+            !! Exponent (`y` in \( b^y = x \))
+
         if (base == 2.0_real64) then
             exponent = log(val)/LOG_2
         else
             exponent = log(val)/log(base)
         end if
-    end subroutine logx
+    end subroutine logx_helper
 
     !> AUTHOR_FRANZ_ERIC_SILL
     !| Initialize Fortran's random number generator

--- a/src/f42/f42_utils.F90
+++ b/src/f42/f42_utils.F90
@@ -262,11 +262,7 @@ contains
 
     !> AUTHOR_FRANZ_ERIC_SILL
     !| (no input validation) Compute logarithm for any base: `log_base(val) = log(val)/log(base)`.
-    !| This is the non-validating core of [[f42_utils(module):logx(subroutine)]], split out so it can
-    !| be called from inside `do concurrent` loops without a shared `ierr` (which would be a data
-    !| race). The caller is responsible for guaranteeing valid inputs beforehand -- `val > 0`,
-    !| `base > 0` and `base /= 1` -- e.g. via an up-front [[tox_errors(module):validate_in_range_real(subroutine)]]
-    !| pass; violating them yields a NaN/Inf result instead of an error code.
+    !| Ensure `val > 0`, `base > 0` and `base /= 1`, yields a NaN/Inf result otherwise.
     pure subroutine logx_helper(val, base, exponent)
         real(real64), intent(in) :: val
             !! Value (`x` in \( b^y = x \)), must be `> 0`

--- a/src/tox/tox_get_outliers.F90
+++ b/src/tox/tox_get_outliers.F90
@@ -5,8 +5,8 @@ module tox_get_outliers
     use safeguard
     use, intrinsic :: iso_fortran_env, only: real64, int32
     use, intrinsic :: ieee_arithmetic, only: ieee_is_nan, ieee_value, ieee_quiet_nan
-    use f42_utils, only: sort_array, calc_percentile, logx_helper, is_close, compute_scaled_distance_quantile, init_perm
-    use tox_errors, only: ERR_INVALID_INPUT, ERR_ALLOC_FAIL, set_ok, set_err, set_err_once, is_err
+    use f42_utils, only: sort_array, calc_percentile, logx_helper, above, is_close, compute_scaled_distance_quantile, init_perm
+    use tox_errors, only: ERR_INVALID_INPUT, ERR_ALLOC_FAIL, set_ok, set_err, set_err_once, is_err, validate_all_in_range_real
     use tox_loess, only: tox_loess_required_workspace, loess_fit_robust, loess_fit_plain, EPS_LOESS, loess_evaluation
     implicit none
 
@@ -191,10 +191,18 @@ contains
         ! Fit the mean-vs-stddev trend in log2 space: intra-family distance stddev scales roughly
         ! multiplicatively with the mean distance, so a log/log relationship is closer to linear
         ! (homoscedastic) than the raw scale, which is what LOESS assumes.
-        ! `loess_x` (family mean distances) and `loess_y` (family distance stddevs) are non-negative by
-        ! construction and `eps_mean`/`eps_sd` are >= EPS_LOESS > 0, so the log arguments are always
-        ! strictly positive. `logx` therefore never faults here, letting the non-validating
-        ! `logx_helper` run in a race-free `do concurrent` with no shared `ierr`.
+        !
+        ! Validate the log2 arguments up front (sequentially, as `ierr` is a shared scalar), exactly as
+        ! `logx` would: `loess_x + eps_mean > 0` and `loess_y + eps_sd > 0`, rejecting NaN/Inf. This
+        ! does not assume the caller's `distances` are well-formed -- a NaN/Inf distance propagates into
+        ! `loess_x`/`loess_y` and is caught here. These same family means feed the second log2 loop
+        ! below via `tmp_means_aux` (identical values), so validating them here covers both loops.
+        ! With the arguments guaranteed valid, the transform runs as a race-free `do concurrent`
+        ! calling the non-validating `logx_helper` -- no per-iteration write to the shared `ierr`.
+        call validate_all_in_range_real(loess_x(1:n_valid) + eps_mean, n_valid, ierr, min=above(0.0_real64))
+        call validate_all_in_range_real(loess_y(1:n_valid) + eps_sd, n_valid, ierr, min=above(0.0_real64))
+        if (is_err(ierr)) return
+
         do concurrent(i_valid=1:n_valid) shared(loess_x, loess_y, eps_mean, eps_sd)
             call logx_helper(loess_x(i_valid) + eps_mean, 2.0_real64, loess_x(i_valid))
             call logx_helper(loess_y(i_valid) + eps_sd, 2.0_real64, loess_y(i_valid))
@@ -272,9 +280,13 @@ contains
 
         if (is_err(ierr)) return
 
-        ! In the `>= 0` branch the log argument is `tmp_means_aux + eps_mean >= eps_mean > 0`, so
-        ! `logx` never faults; the non-validating `logx_helper` lets this run as a race-free
-        ! `do concurrent` with no shared `ierr` (each iteration writes only its own `tmp_z_mat` row).
+        ! The `>= 0` branch feeds `tmp_means_aux(i_family) + eps_mean` to log2. Every such family had
+        ! `n_in_family > 1` and therefore contributed exactly this mean to `loess_x`, whose
+        ! `+ eps_mean` argument was already validated (> 0, finite) before the first log2 loop above;
+        ! skipped families keep the initial `tmp_means_aux = -1` and take the `else` branch. So the
+        ! argument here is guaranteed valid by that earlier validation -- not by assumption -- and the
+        ! non-validating `logx_helper` runs in a race-free `do concurrent` with no shared `ierr`
+        ! (each iteration writes only its own `tmp_z_mat` row).
         do concurrent(i_family=1:n_families) shared(tmp_means_aux, tmp_z_mat, eps_mean, xmin, xmax)
             if (tmp_means_aux(i_family) >= 0.0_real64) then
                 call logx_helper(tmp_means_aux(i_family) + eps_mean, 2.0_real64, tmp_z_mat(i_family, 1))

--- a/src/tox/tox_get_outliers.F90
+++ b/src/tox/tox_get_outliers.F90
@@ -5,7 +5,7 @@ module tox_get_outliers
     use safeguard
     use, intrinsic :: iso_fortran_env, only: real64, int32
     use, intrinsic :: ieee_arithmetic, only: ieee_is_nan, ieee_value, ieee_quiet_nan
-    use f42_utils, only: sort_array, calc_percentile, logx, is_close, compute_scaled_distance_quantile, init_perm
+    use f42_utils, only: sort_array, calc_percentile, logx_helper, is_close, compute_scaled_distance_quantile, init_perm
     use tox_errors, only: ERR_INVALID_INPUT, ERR_ALLOC_FAIL, set_ok, set_err, set_err_once, is_err
     use tox_loess, only: tox_loess_required_workspace, loess_fit_robust, loess_fit_plain, EPS_LOESS, loess_evaluation
     implicit none
@@ -95,7 +95,7 @@ contains
             !! Error code
 
         ! Local variables
-        integer(int32) :: i_gene, i_family, i_valid, family_idx, n_in_family, n_valid, k, tmp_ierr
+        integer(int32) :: i_gene, i_family, i_valid, family_idx, n_in_family, n_valid, k
         real(real64)   :: stddev_dist, mean_dist, sumsq, dist_val
         real(real64) :: xmin, xmax, eps_mean, eps_sd, std_median
 
@@ -191,17 +191,14 @@ contains
         ! Fit the mean-vs-stddev trend in log2 space: intra-family distance stddev scales roughly
         ! multiplicatively with the mean distance, so a log/log relationship is closer to linear
         ! (homoscedastic) than the raw scale, which is what LOESS assumes.
-        ! NOTE: kept as a plain sequential loop (not `do concurrent`) because `ierr` is a shared
-        ! scalar conditionally written on the (rare/exceptional) error path -- writing it from
-        ! concurrent iterations would be an unsynchronized data race.
-        do i_valid = 1, n_valid
-            call logx(loess_x(i_valid) + eps_mean, 2.0_real64, loess_x(i_valid), tmp_ierr)
-            if (is_err(tmp_ierr)) ierr = tmp_ierr
-            call logx(loess_y(i_valid) + eps_sd, 2.0_real64, loess_y(i_valid), tmp_ierr)
-            if (is_err(tmp_ierr)) ierr = tmp_ierr
+        ! `loess_x` (family mean distances) and `loess_y` (family distance stddevs) are non-negative by
+        ! construction and `eps_mean`/`eps_sd` are >= EPS_LOESS > 0, so the log arguments are always
+        ! strictly positive. `logx` therefore never faults here, letting the non-validating
+        ! `logx_helper` run in a race-free `do concurrent` with no shared `ierr`.
+        do concurrent(i_valid=1:n_valid) shared(loess_x, loess_y, eps_mean, eps_sd)
+            call logx_helper(loess_x(i_valid) + eps_mean, 2.0_real64, loess_x(i_valid))
+            call logx_helper(loess_y(i_valid) + eps_sd, 2.0_real64, loess_y(i_valid))
         end do
-
-        if (is_err(ierr)) return
 
         call init_perm(tmp_perm)
         call sort_array(loess_y(1:n_valid), tmp_perm(1:n_valid), tmp_stack_left(1:n_valid), tmp_stack_right(1:n_valid))
@@ -275,24 +272,18 @@ contains
 
         if (is_err(ierr)) return
 
-        ! NOTE: kept as a plain sequential loop (not `do concurrent`) because `ierr` is a shared
-        ! scalar conditionally written on the (rare/exceptional) error path -- writing it from
-        ! concurrent iterations would be an unsynchronized data race.
-        do i_family = 1, n_families
+        ! In the `>= 0` branch the log argument is `tmp_means_aux + eps_mean >= eps_mean > 0`, so
+        ! `logx` never faults; the non-validating `logx_helper` lets this run as a race-free
+        ! `do concurrent` with no shared `ierr` (each iteration writes only its own `tmp_z_mat` row).
+        do concurrent(i_family=1:n_families) shared(tmp_means_aux, tmp_z_mat, eps_mean, xmin, xmax)
             if (tmp_means_aux(i_family) >= 0.0_real64) then
-                call logx(tmp_means_aux(i_family) + eps_mean, 2.0_real64, tmp_z_mat(i_family, 1), tmp_ierr)
-                if (is_err(tmp_ierr)) then
-                    ierr = tmp_ierr
-                else
-                    if (tmp_z_mat(i_family, 1) < xmin) tmp_z_mat(i_family, 1) = xmin
-                    if (tmp_z_mat(i_family, 1) > xmax) tmp_z_mat(i_family, 1) = xmax
-                end if
+                call logx_helper(tmp_means_aux(i_family) + eps_mean, 2.0_real64, tmp_z_mat(i_family, 1))
+                if (tmp_z_mat(i_family, 1) < xmin) tmp_z_mat(i_family, 1) = xmin
+                if (tmp_z_mat(i_family, 1) > xmax) tmp_z_mat(i_family, 1) = xmax
             else
                 tmp_z_mat(i_family, 1) = xmin
             end if
         end do
-
-        if (is_err(ierr)) return
 
         call loess_evaluation(tmp_iv, liv, lv, tmp_wv, n_families, tmp_z_mat(1:n_families, 1:1), tmp_yhat(1:n_families))
 

--- a/src/tox/tox_normalization.F90
+++ b/src/tox/tox_normalization.F90
@@ -4,8 +4,8 @@
 module tox_normalization
     use safeguard
     use, intrinsic :: iso_fortran_env, only: real64, int32
-    use tox_errors, only: set_ok, set_err, ERR_EMPTY_INPUT, ERR_DIVISION_BY_ZERO, ERR_INVALID_INPUT, is_err, validate_dimension_size, validate_in_range_real, ERR_ALLOC_FAIL, validate_all_in_range_int, ERR_SIZE_MISMATCH
-    use f42_utils, only: norm, is_close, logx, mean, std_dev
+    use tox_errors, only: set_ok, set_err, ERR_EMPTY_INPUT, ERR_DIVISION_BY_ZERO, ERR_INVALID_INPUT, is_err, validate_dimension_size, validate_in_range_real, ERR_ALLOC_FAIL, validate_all_in_range_int, validate_all_in_range_real, ERR_SIZE_MISMATCH
+    use f42_utils, only: norm, is_close, logx_helper, above, mean, std_dev
     use tox_loess, only: loess_alloc
 
 #define CM_LOESS_SPAN_DEFAULT 0.7_real64
@@ -473,21 +473,23 @@ contains
         integer(int32), intent(out) :: ierr
             !! Error code
         ! Locals
-        integer(int32) :: i_gene, i_group, tmp_ierr
+        integer(int32) :: i_gene, i_group
         real(real64) :: expr_val
 
         call set_ok(ierr)
 
-        ! Loop through all elements in the flattened input matrix
-        ! NOTE: kept as a plain sequential loop (not `do concurrent`) because `ierr` is a shared
-        ! scalar written on the (rare/exceptional) error path -- writing it from concurrent
-        ! iterations would be an unsynchronized data race.
-        do i_gene = 1, n_genes
-            do i_group = 1, n_tissues
-                ! Apply the log2(x + 1) transformation
+        ! Validate every element up front (sequentially, as `ierr` is a shared scalar here) so that
+        ! `log2(x + 1)` is only ever evaluated for `x + 1 > 0`, i.e. `x > -1`. With the inputs
+        ! guaranteed valid, the transformation itself can run as a race-free `do concurrent` calling
+        ! the non-validating `logx_helper` -- no per-iteration write to the shared `ierr` is needed.
+        call validate_all_in_range_real(expr, n_genes*n_tissues, ierr, min=above(-1.0_real64))
+        if (is_err(ierr)) return
+
+        ! Apply the log2(x + 1) transformation to every element in the flattened input matrix
+        do concurrent(i_gene=1:n_genes) shared(expr, n_tissues)
+            do concurrent(i_group=1:n_tissues) local(expr_val) shared(expr, i_gene)
                 expr_val = expr(i_group, i_gene) + 1.0_real64
-                call logx(expr_val, 2.0_real64, expr(i_group, i_gene), tmp_ierr)
-                if (is_err(tmp_ierr)) ierr = tmp_ierr
+                call logx_helper(expr_val, 2.0_real64, expr(i_group, i_gene))
             end do
         end do
     end subroutine log2_transformation_inplace_helper

--- a/test/mod_test_get_outliers.F90
+++ b/test/mod_test_get_outliers.F90
@@ -12,7 +12,7 @@ contains
   !> @brief Get array of all available tests (as subroutine, not function).
   function get_all_tests_get_outliers() result(all_tests)
     type(test_case), allocatable :: all_tests(:)
-    allocate(all_tests(24))
+    allocate(all_tests(25))
 
     all_tests(1) = test_case("test_scaling_basic", test_scaling_basic)
     all_tests(2) = test_case("test_rdi_basic", test_rdi_basic)
@@ -38,6 +38,7 @@ contains
     all_tests(22) = test_case("test_outliers_extreme_detection", test_outliers_extreme_detection)
     all_tests(23) = test_case("test_outliers_nan_handling", test_outliers_nan_handling)
     all_tests(24) = test_case("test_scaling_performance_benchmark",test_scaling_performance_benchmark)
+    all_tests(25) = test_case("test_family_scaling_non_finite_distance", test_family_scaling_non_finite_distance)
 
   end function get_all_tests_get_outliers
 
@@ -835,6 +836,35 @@ contains
     call assert_equal_int(ierr, 0, 'Error code 0 for single-gene families')
     call assert_true(all(dscale == 0.0_real64), 'All singleton families scaling 0.0')
   end subroutine test_single_gene_family_scaling
+
+  !> A non-finite distance must surface as an error, not silently flow into log2.
+  !| `compute_family_scaling` feeds family means/stddevs to `logx_helper` (non-validating) inside a
+  !| `do concurrent`. The callee validates those log2 arguments up front so a NaN/Inf distance -- which
+  !| propagates into a family mean -- is rejected with `ierr`, rather than producing a NaN/Inf scale.
+  subroutine test_family_scaling_non_finite_distance()
+    use, intrinsic :: iso_fortran_env, only: int32, real64
+    use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_positive_inf
+    implicit none
+
+    integer(int32), parameter :: n_families = 2_int32
+    integer(int32), parameter :: n_genes    = 4_int32
+
+    real(real64)   :: distances(n_genes)
+    integer(int32) :: gene_to_fam(n_genes) = [1_int32, 1_int32, 2_int32, 2_int32]
+    real(real64)   :: dscale(n_families)
+    real(real64)   :: loess_x(n_families), loess_y(n_families)
+    integer(int32) :: indices_used(n_families)
+    integer(int32) :: ierr
+
+    ! Two families of two genes each (so n_valid = 2, past the single-family early return); one
+    ! distance is +Inf, making that family's mean +Inf.
+    distances = [ieee_value(1.0_real64, ieee_positive_inf), 1.0_real64, 2.0_real64, 3.0_real64]
+
+    call compute_family_scaling_alloc(n_genes, n_families, distances, gene_to_fam, dscale, &
+                                      loess_x, loess_y, indices_used, ierr)
+
+    call assert_true(ierr /= 0, "Non-finite family mean must error, not reach log2 silently")
+  end subroutine test_family_scaling_non_finite_distance
 
   subroutine test_all_zero_distances_scaling()
     use, intrinsic :: iso_fortran_env, only: int32, real64

--- a/test/mod_test_log2_normalization.F90
+++ b/test/mod_test_log2_normalization.F90
@@ -13,7 +13,7 @@ contains
     function get_all_tests_log2_transformation() result(all_tests)
         type(test_case), allocatable :: all_tests(:)
 
-        allocate (all_tests(13))
+        allocate (all_tests(14))
         all_tests(1) = test_case("test_log2_basic_values", test_log2_basic_values)
         all_tests(2) = test_case("test_log2_zeros_handling", test_log2_zeros_handling)
         all_tests(3) = test_case("test_log2_preserves_dimensions", test_log2_preserves_dimensions)
@@ -27,6 +27,7 @@ contains
         all_tests(11) = test_case("test_log2_monotonic_property", test_log2_monotonic_property)
         all_tests(12) = test_case("test_log2_mathematical_properties", test_log2_mathematical_properties)
         all_tests(13) = test_case("test_log2_empty_matrix", test_log2_empty_matrix)
+        all_tests(14) = test_case("test_log2_below_minus_one_errors", test_log2_below_minus_one_errors)
     end function get_all_tests_log2_transformation
 
     !> Test log2(x+1) transformation with basic known values (from R test).
@@ -281,5 +282,26 @@ contains
         call assert_equal_int(ierr, 202, "log2_transformation_r should return error for empty input")
         ! No further assertion needed: just check no crash
     end subroutine test_log2_empty_matrix
+
+    !> Test that inputs at or below -1 (where log2(x+1) is undefined) are rejected.
+    !| Guards the up-front validation that lets the transformation loop run as a
+    !| race-free `do concurrent`: `x <= -1` means `x + 1 <= 0`, which must error
+    !| rather than silently produce a NaN/Inf.
+    subroutine test_log2_below_minus_one_errors()
+        integer(int32) :: n_genes, n_tissues, ierr
+        real(real64), dimension(4) :: input_flat, output_flat
+
+        n_genes = 2; n_tissues = 2
+
+        ! Exactly -1 -> log2(0) is undefined
+        input_flat = [0.0d0, 1.0d0, -1.0d0, 3.0d0]
+        call log2_transformation(n_genes, n_tissues, input_flat, output_flat, ierr)
+        call assert_equal_int(ierr, 201, "test_log2_below_minus_one_errors: x = -1 should return ERR_INVALID_INPUT")
+
+        ! Below -1 -> log2 of a negative number
+        input_flat = [0.0d0, 1.0d0, 3.0d0, -2.5d0]
+        call log2_transformation(n_genes, n_tissues, input_flat, output_flat, ierr)
+        call assert_equal_int(ierr, 201, "test_log2_below_minus_one_errors: x < -1 should return ERR_INVALID_INPUT")
+    end subroutine test_log2_below_minus_one_errors
 
 end module mod_test_log2_transformation


### PR DESCRIPTION
Closes #158.

## Audit result

Reviewed **every** `do concurrent` loop that touches an `ierr`/status code.

**No `do concurrent` loop currently writes a shared scalar `ierr`.** The race
flagged in PR #135 (`tox_errors.F90`) was the only one and was already fixed
there. Every `do concurrent` loop that calls a subroutine (euclidean distance,
gene centroids, trajectory velocity, JSD percentile, …) already writes into a
distinct per-iteration array slot via a **non-validating** helper — the
established safe pattern.

## What this PR changes

Three loops had been kept **sequential** *solely* because they folded a shared
`ierr` written on the error path of `logx` (which validates its own argument).
That was the only blocker to parallelizing them. Following the "non-validating
helper" convention used everywhere else:

- Split the pure math out of `logx` into **`logx_helper`** (no validation, no
  `ierr`); `logx` keeps its validating contract by delegating to it.
- **`log2_transformation_inplace_helper`** — validate `x > -1` up front (bulk,
  sequential — the accepted place for shared-`ierr` validation), then run the
  `log2(x+1)` transform as a `do concurrent` calling `logx_helper`.
- **`compute_family_scaling`** (two loops) — validate the log2 arguments up
  front, exactly as `logx` would (`> 0`, reject NaN/Inf), then call
  `logx_helper` under `do concurrent`. The callee does **not** assume the
  caller's `distances` are well-formed: a NaN/Inf distance propagates into a
  family mean and is now caught (previously `compute_family_scaling` validated
  only family *indices*, never distance *values*). The raw means validated for
  the first loop are the same values the second loop reads via `tmp_means_aux`,
  so one up-front check provably covers both loops.

## Shared-`ierr` cases intentionally left sequential (none are unresolved races)

Every case where a shared `ierr` was the *sole* blocker to parallelism is now
resolved. The remaining shared-`ierr` writes are all sequential for reasons
that removing `ierr` would not change:

- **Validation routines** (`tox_errors`, `tox_data_validation`): the loop's
  only job is to accumulate the error code — this is the accepted convention.
- **Sequential by construction**: file I/O (`tox_data_tools`,
  `tox_data_archive`), hashset/linked-list traversal (`f42_xxh3_hashmap`),
  subset generation/recursion (`tox_paralog_analysis`), and loops reusing a
  single shared scratch buffer (`tox_conversions` string buffer,
  `tox_trajectory_contribution_analysis` `tmp_*` buffers). `ierr` is incidental.
- `tox_trajectory_normalization` already uses the per-element `status(...)`
  **array** pattern the issue cites as the reference.

## Tests

- `test_log2_below_minus_one_errors` — covers the log2 up-front validation
  (`x = -1` and `x < -1` → `ERR_INVALID_INPUT`).
- `test_family_scaling_non_finite_distance` — a +Inf distance across two valid
  families now errors instead of silently reaching `log2`.
- Existing `log2_transformation`, `get_outliers`, and `normalization_pipeline`
  suites (which exercise the converted loops) all pass; the exact-value log2
  tests confirm the `do concurrent` path is numerically identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)